### PR TITLE
chore(package): remove "request" dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 const Observable = require('rx').Observable
-const request = require('request')
+const hyperquest = require('hyperquest')
 const LineStream = require('byline').LineStream
 
 function observableEventSource (obj) {
@@ -11,8 +11,7 @@ function observableEventSource (obj) {
   const observable = Observable.create((o) => {
     var parseState = {}
 
-    request({
-      url: url,
+    hyperquest(url, {
       headers: {
         Accept: 'text/eventsource'
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "byline": "^4.2.1",
-    "request": "^2.69.0",
+    "hyperquest": "^1.2.0",
     "rx": "^4.0.7"
   }
 }


### PR DESCRIPTION
The "request" dependency pulls in a whole bunch of modules that aren't
need by observable-event-source.
